### PR TITLE
Switch project to Python 3 and uv workflows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,36 @@ traintimes
 A Python SDK for `realtimetrains <http://www.realtimetrains.co.uk/>`_' API `api.rtt.io <https://api.rtt.io/>`_ (`docs <http://www.realtimetrains.co.uk/api>`_)
 
 
+Development setup
+-----------------
+
+The project now targets Python 3.  You can create a virtual environment and
+install the dependencies using `uv <https://github.com/astral-sh/uv>`_::
+
+    uv venv --python 3.11 .venv
+    source .venv/bin/activate
+    uv pip install -e .
+    uv pip install pytest pytest-cov freezegun
+
+The SDK requires access to the RealTimeTrains API.  Obtain credentials from
+https://api.rtt.io/ and expose them to the process in the
+``RTT_AUTH`` environment variable, formatted as ``username:password``.
+
+Running the test suite
+----------------------
+
+With the dependencies installed you can execute the unit tests via::
+
+    pytest
+
+The integration tests in ``tests/test_sdk_integration.py`` make live requests
+against the RealTimeTrains API.  They count against the daily free tier limit
+and therefore require valid ``RTT_AUTH`` credentials.  When running in an
+environment without outbound network access, or without API credentials, the
+tests will fail during collection because their dependencies (``requests``,
+``requests-cache`` and ``freezegun``) cannot be installed.
+
+
 SDK Classes
 -----------
 - Location List

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from traintimes.sdk import Location, Service
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def dt():
     with freeze_time("2015-10-16 21:52:00"):
         yield

--- a/traintimes/sdk.py
+++ b/traintimes/sdk.py
@@ -36,7 +36,7 @@ class RTTBase(object):
         return self.uri
 
     def get(self):
-        print self
+        print(self)
         response = requests.get(self.uri, auth=self.auth, verify=False)
         assert response.ok, response
         json_data = response.json()


### PR DESCRIPTION
## Summary
- update the SDK logging to use Python 3 syntax
- refresh the pytest fixture syntax to drop the deprecated yield fixture decorator
- rewrite the README development setup instructions for Python 3 using uv tooling

## Testing
- `pytest -c /dev/null` *(fails: missing dependency freezegun in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24e718b08832fae982f9f804c6583